### PR TITLE
Add owner as argument

### DIFF
--- a/script/WormholeDeploy.s.sol
+++ b/script/WormholeDeploy.s.sol
@@ -31,7 +31,7 @@ contract Deploy is Script, Constants {
     // Create L2 ERC20Votes token
     vm.broadcast();
     WormholeL2ERC20 l2Token =
-    new WormholeL2ERC20("Scopeapotomus", "SCOPE", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId);
+    new WormholeL2ERC20("Scopeapotomus", "SCOPE", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
 
     vm.createSelectFork(L1_CHAIN.rpcUrl);
 
@@ -42,7 +42,7 @@ contract Deploy is Script, Constants {
     // Create L1 bridge that mints the L2 token
     vm.broadcast();
     WormholeL1ERC20Bridge bridge =
-    new WormholeL1ERC20Bridge(deployedL1Token, L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new WormholeL1ERC20Bridge(deployedL1Token, L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
 
     // Tell the bridge its corresponding L2 token
     vm.broadcast();

--- a/script/WormholeDeployGovernorMetadata.s.sol
+++ b/script/WormholeDeployGovernorMetadata.s.sol
@@ -30,7 +30,7 @@ contract DeployGovernorMetadata is Script, Constants {
     // Deploy the L2 metadata contract
     vm.broadcast();
     WormholeL2GovernorMetadata l2GovernorMetadata =
-      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
 
     vm.createSelectFork(L1_CHAIN.rpcUrl);
 

--- a/src/WormholeL1ERC20Bridge.sol
+++ b/src/WormholeL1ERC20Bridge.sol
@@ -36,8 +36,14 @@ contract WormholeL1ERC20Bridge is WormholeL1VotePool, WormholeSender, WormholeRe
     address _relayer,
     address _governor,
     uint16 _sourceChain,
-    uint16 _targetChain
-  ) WormholeL1VotePool(_governor) WormholeBase(_relayer) WormholeSender(_sourceChain, _targetChain) {
+    uint16 _targetChain,
+    address _owner
+  )
+    WormholeL1VotePool(_governor)
+    WormholeBase(_relayer)
+    WormholeSender(_sourceChain, _targetChain)
+    WormholeReceiver(_owner)
+  {
     L1_TOKEN = ERC20Votes(l1TokenAddress);
   }
 

--- a/src/WormholeL2ERC20.sol
+++ b/src/WormholeL2ERC20.sol
@@ -36,12 +36,14 @@ contract WormholeL2ERC20 is ERC20Votes, WormholeReceiver, WormholeSender {
     address _relayer,
     address _l1Block,
     uint16 _sourceChain,
-    uint16 _targetChain
+    uint16 _targetChain,
+    address _owner
   )
     WormholeBase(_relayer)
     ERC20(_name, _symbol)
     ERC20Permit(_name)
     WormholeSender(_sourceChain, _targetChain)
+    WormholeReceiver(_owner)
   {
     L1_BLOCK = IL1Block(_l1Block);
   }

--- a/src/WormholeL2GovernorMetadata.sol
+++ b/src/WormholeL2GovernorMetadata.sol
@@ -8,7 +8,11 @@ import {L2GovernorMetadata} from "src/L2GovernorMetadata.sol";
 /// @notice Use Wormhole to receive L1 proposal metadata.
 contract WormholeL2GovernorMetadata is L2GovernorMetadata, WormholeReceiver {
   /// @param _relayer The address of thWormholeL2GovernorMetadata contract.
-  constructor(address _relayer) WormholeBase(_relayer) L2GovernorMetadata() {}
+  constructor(address _relayer, address _owner)
+    WormholeBase(_relayer)
+    WormholeReceiver(_owner)
+    L2GovernorMetadata()
+  {}
 
   /// @notice Receives a message from L1 and saves the proposal metadata.
   /// @param payload The payload that was sent to in the delivery request.

--- a/src/WormholeReceiver.sol
+++ b/src/WormholeReceiver.sol
@@ -22,6 +22,10 @@ abstract contract WormholeReceiver is Ownable, WormholeBase {
   /// @dev A mapping of message hash to a boolean indicating delivery.
   mapping(bytes32 => bool) public seenDeliveryVaaHashes;
 
+  constructor(address owner) Ownable() {
+    transferOwnership(owner);
+  }
+
   /// @notice The function the wormhole relayer calls when the DeliveryProvider competes a delivery.
   /// @param payload The payload that was sent to in the delivery request.
   /// @param additionalVaas The additional VAAs that requested to be relayed.

--- a/test/WormholeL1ERC20Bridge.t.sol
+++ b/test/WormholeL1ERC20Bridge.t.sol
@@ -60,6 +60,7 @@ contract L1ERC20BridgeTest is Constants, WormholeRelayerBasicTest {
     L1Block l1Block = new L1Block();
     l2Erc20 =
     new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
+	vm.prank(l2Erc20.owner());
     l2Erc20.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1Erc20Bridge))))
     );

--- a/test/WormholeL1ERC20Bridge.t.sol
+++ b/test/WormholeL1ERC20Bridge.t.sol
@@ -19,8 +19,9 @@ contract L1ERC20BridgeHarness is WormholeL1ERC20Bridge {
     address _l1Relayer,
     address _l1Governor,
     uint16 _sourceId,
-    uint16 _targetId
-  ) WormholeL1ERC20Bridge(_l1Token, _l1Relayer, _l1Governor, _sourceId, _targetId) {}
+    uint16 _targetId,
+    address _owner
+  ) WormholeL1ERC20Bridge(_l1Token, _l1Relayer, _l1Governor, _sourceId, _targetId, _owner) {}
 
   function withdraw(address account, uint256 amount) public {
     _withdraw(account, amount);
@@ -52,13 +53,13 @@ contract L1ERC20BridgeTest is Constants, WormholeRelayerBasicTest {
     l1Erc20 = new FakeERC20("Hello", "WRLD");
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     l1Erc20Bridge =
-    new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
   }
 
   function setUpTarget() public override {
     L1Block l1Block = new L1Block();
     l2Erc20 =
-    new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId);
+    new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
     l2Erc20.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1Erc20Bridge))))
     );
@@ -70,7 +71,7 @@ contract Constructor is Test, Constants {
     FakeERC20 l1Erc20 = new FakeERC20("Hello", "WRLD");
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     WormholeL1ERC20Bridge l1Erc20Bridge =
-    new WormholeL1ERC20Bridge(address(l1Erc), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new WormholeL1ERC20Bridge(address(l1Erc), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
     assertEq(address(l1Erc20Bridge.L1_TOKEN()), l1Erc, "L1 token is not set correctly");
   }
 }
@@ -124,7 +125,7 @@ contract _ReceiveWithdrawalWormholeMessages is Test, Constants {
     FakeERC20 l1Erc20 = new FakeERC20("Hello", "WRLD");
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     L1ERC20BridgeHarness l1Erc20Bridge =
-    new L1ERC20BridgeHarness(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new L1ERC20BridgeHarness(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
 
     l1Erc20Bridge.initialize(address(l2Erc20));
     l1Erc20.approve(address(this), _amount);
@@ -151,7 +152,7 @@ contract _Withdraw is Test, Constants {
     FakeERC20 l1Erc20 = new FakeERC20("Hello", "WRLD");
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     L1ERC20BridgeHarness l1Erc20Bridge =
-    new L1ERC20BridgeHarness(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new L1ERC20BridgeHarness(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
     l1Erc20Bridge.initialize(address(l2Erc20));
 
     l1Erc20.approve(address(this), _amount);

--- a/test/WormholeL1ERC20Bridge.t.sol
+++ b/test/WormholeL1ERC20Bridge.t.sol
@@ -60,7 +60,7 @@ contract L1ERC20BridgeTest is Constants, WormholeRelayerBasicTest {
     L1Block l1Block = new L1Block();
     l2Erc20 =
     new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
-	vm.prank(l2Erc20.owner());
+    vm.prank(l2Erc20.owner());
     l2Erc20.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1Erc20Bridge))))
     );

--- a/test/WormholeL1GovernorMetadataBridge.t.sol
+++ b/test/WormholeL1GovernorMetadataBridge.t.sol
@@ -32,6 +32,7 @@ contract L1GovernorMetadataBridgeTest is Constants, WormholeRelayerBasicTest {
 
   function setUpTarget() public override {
     l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+	vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1GovernorMetadataBridge))))
     );

--- a/test/WormholeL1GovernorMetadataBridge.t.sol
+++ b/test/WormholeL1GovernorMetadataBridge.t.sol
@@ -31,7 +31,7 @@ contract L1GovernorMetadataBridgeTest is Constants, WormholeRelayerBasicTest {
   }
 
   function setUpTarget() public override {
-    l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+    l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1GovernorMetadataBridge))))
     );

--- a/test/WormholeL1GovernorMetadataBridge.t.sol
+++ b/test/WormholeL1GovernorMetadataBridge.t.sol
@@ -32,7 +32,7 @@ contract L1GovernorMetadataBridgeTest is Constants, WormholeRelayerBasicTest {
 
   function setUpTarget() public override {
     l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
-	vm.prank(l2GovernorMetadata.owner());
+    vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1GovernorMetadataBridge))))
     );

--- a/test/WormholeL1VotePool.t.sol
+++ b/test/WormholeL1VotePool.t.sol
@@ -22,6 +22,7 @@ contract L1VotePoolHarness is WormholeL1VotePool, WormholeReceiver, Test {
   constructor(address _relayer, address _governor)
     WormholeBase(_relayer)
     WormholeL1VotePool(_governor)
+    WormholeReceiver(msg.sender)
   {}
 
   function _jumpToActiveProposal(uint256 proposalId) internal {

--- a/test/WormholeL2ERC20.t.sol
+++ b/test/WormholeL2ERC20.t.sol
@@ -26,6 +26,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     L1Block l1Block = new L1Block();
     l2Erc20 =
     new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
+	vm.prank(l2Erc20.owner());
     l2Erc20.setRegisteredSender(L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS);
   }
 
@@ -34,6 +35,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     l1Erc20Bridge =
     new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
+	vm.prank(l1Erc20Bridge.owner());
     l1Erc20Bridge.setRegisteredSender(
       L2_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l2Erc20))))
     );

--- a/test/WormholeL2ERC20.t.sol
+++ b/test/WormholeL2ERC20.t.sol
@@ -25,7 +25,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
   function setUpSource() public override {
     L1Block l1Block = new L1Block();
     l2Erc20 =
-    new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId);
+    new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
     l2Erc20.setRegisteredSender(L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS);
   }
 
@@ -33,7 +33,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     l1Erc20 = new FakeERC20("Hello", "WRLD");
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     l1Erc20Bridge =
-    new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId);
+    new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
     l1Erc20Bridge.setRegisteredSender(
       L2_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l2Erc20))))
     );
@@ -44,7 +44,7 @@ contract Constructor is L2ERC20Test {
   function testFuzz_CorrectlySetsAllArgs() public {
     L1Block l1Block = new L1Block();
     WormholeL2ERC20 erc20 =
-    new WormholeL2ERC20( "Hello", "WRLD", 0x0CBE91CF822c73C2315FB05100C2F714765d5c20, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId);
+    new WormholeL2ERC20( "Hello", "WRLD", 0x0CBE91CF822c73C2315FB05100C2F714765d5c20, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
 
     assertEq(address(l1Block), address(erc20.L1_BLOCK()));
   }

--- a/test/WormholeL2ERC20.t.sol
+++ b/test/WormholeL2ERC20.t.sol
@@ -26,7 +26,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     L1Block l1Block = new L1Block();
     l2Erc20 =
     new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
-	vm.prank(l2Erc20.owner());
+    vm.prank(l2Erc20.owner());
     l2Erc20.setRegisteredSender(L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS);
   }
 
@@ -35,7 +35,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     l1Erc20Bridge =
     new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
-	vm.prank(l1Erc20Bridge.owner());
+    vm.prank(l1Erc20Bridge.owner());
     l1Erc20Bridge.setRegisteredSender(
       L2_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l2Erc20))))
     );

--- a/test/WormholeL2ERC20.t.sol
+++ b/test/WormholeL2ERC20.t.sol
@@ -26,6 +26,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     L1Block l1Block = new L1Block();
     l2Erc20 =
     new WormholeL2ERC20( "Hello", "WRLD", L2_CHAIN.wormholeRelayer, address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId, msg.sender);
+
     vm.prank(l2Erc20.owner());
     l2Erc20.setRegisteredSender(L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS);
   }
@@ -35,6 +36,7 @@ contract L2ERC20Test is Constants, WormholeRelayerBasicTest {
     IGovernor gov = new GovernorMock("Testington Dao", l1Erc20);
     l1Erc20Bridge =
     new WormholeL1ERC20Bridge(address(l1Erc20), L1_CHAIN.wormholeRelayer, address(gov), L1_CHAIN.wormholeChainId, L2_CHAIN.wormholeChainId, msg.sender);
+
     vm.prank(l1Erc20Bridge.owner());
     l1Erc20Bridge.setRegisteredSender(
       L2_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l2Erc20))))

--- a/test/WormholeL2GovernorMetadata.t.sol
+++ b/test/WormholeL2GovernorMetadata.t.sol
@@ -13,7 +13,7 @@ contract L2GovernorMetadataTest is Constants {
 
   function setUp() public {
     l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
-	vm.prank(l2GovernorMetadata.owner());
+    vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );

--- a/test/WormholeL2GovernorMetadata.t.sol
+++ b/test/WormholeL2GovernorMetadata.t.sol
@@ -12,7 +12,7 @@ contract L2GovernorMetadataTest is Constants {
   WormholeL2GovernorMetadata l2GovernorMetadata;
 
   function setUp() public {
-    l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+    l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -21,7 +21,8 @@ contract L2GovernorMetadataTest is Constants {
 
 contract Constructor is L2GovernorMetadataTest {
   function testFuzz_CorrectlySetsAllArgs(address wormholeCore) public {
-    new WormholeL2GovernorMetadata(wormholeCore); // nothing to assert as there are no constructor
+    new WormholeL2GovernorMetadata(wormholeCore, msg.sender); // nothing to assert as there are no
+      // constructor
       // args set
   }
 }

--- a/test/WormholeL2GovernorMetadata.t.sol
+++ b/test/WormholeL2GovernorMetadata.t.sol
@@ -13,6 +13,7 @@ contract L2GovernorMetadataTest is Constants {
 
   function setUp() public {
     l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+	vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );

--- a/test/WormholeL2GovernorMetadata.t.sol
+++ b/test/WormholeL2GovernorMetadata.t.sol
@@ -23,8 +23,7 @@ contract L2GovernorMetadataTest is Constants {
 contract Constructor is L2GovernorMetadataTest {
   function testFuzz_CorrectlySetsAllArgs(address wormholeCore) public {
     new WormholeL2GovernorMetadata(wormholeCore, msg.sender); // nothing to assert as there are no
-      // constructor
-      // args set
+      // constructor args set
   }
 }
 

--- a/test/WormholeL2VoteAggregator.t.sol
+++ b/test/WormholeL2VoteAggregator.t.sol
@@ -24,6 +24,7 @@ contract L1VotePoolHarness is WormholeL1VotePool, WormholeReceiver, Test {
   constructor(address _relayer, address _l1Governor)
     WormholeBase(_relayer)
     WormholeL1VotePool(_l1Governor)
+    WormholeReceiver(msg.sender)
   {}
 
   function receiveWormholeMessages(
@@ -321,7 +322,7 @@ contract InternalVotingPeriodEnd is L2VoteAggregatorTest {
     public
   {
     WormholeL2GovernorMetadata l2GovernorMetadata =
-      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -350,10 +351,11 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
     public
   {
     WormholeL2GovernorMetadata l2GovernorMetadata =
-      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
+
     L2VoteAggregator aggregator =
     new WormholeL2VoteAggregator(address(l2Erc20), L2_CHAIN.wormholeRelayer, address(l2GovernorMetadata), address(l1Block), L2_CHAIN.wormholeChainId, L1_CHAIN.wormholeChainId);
 
@@ -382,7 +384,7 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
     uint64 voteEnd
   ) public {
     WormholeL2GovernorMetadata l2GovernorMetadata =
-      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer);
+      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );

--- a/test/WormholeL2VoteAggregator.t.sol
+++ b/test/WormholeL2VoteAggregator.t.sol
@@ -323,6 +323,8 @@ contract InternalVotingPeriodEnd is L2VoteAggregatorTest {
   {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+
+	vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -352,6 +354,8 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
   {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+
+	vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -385,6 +389,8 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
   ) public {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+
+	vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );

--- a/test/WormholeL2VoteAggregator.t.sol
+++ b/test/WormholeL2VoteAggregator.t.sol
@@ -324,7 +324,7 @@ contract InternalVotingPeriodEnd is L2VoteAggregatorTest {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
 
-	vm.prank(l2GovernorMetadata.owner());
+    vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -355,7 +355,7 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
 
-	vm.prank(l2GovernorMetadata.owner());
+    vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );
@@ -390,7 +390,7 @@ contract ProposalVoteActive is L2VoteAggregatorTest {
     WormholeL2GovernorMetadata l2GovernorMetadata =
       new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
 
-	vm.prank(l2GovernorMetadata.owner());
+    vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
     );

--- a/test/WormholeReceiver.t.sol
+++ b/test/WormholeReceiver.t.sol
@@ -8,7 +8,7 @@ import {WormholeReceiver} from "src/WormholeReceiver.sol";
 import {Constants} from "test/Constants.sol";
 
 contract WormholeReceiverTestHarness is WormholeReceiver {
-  constructor(address _relayer) WormholeBase(_relayer) {}
+  constructor(address _relayer) WormholeBase(_relayer) WormholeReceiver(msg.sender) {}
   function receiveWormholeMessages(
     bytes memory payload,
     bytes[] memory additionalVaas,

--- a/test/WormholeReceiver.t.sol
+++ b/test/WormholeReceiver.t.sol
@@ -67,7 +67,9 @@ contract SetRegisteredSender is WormholeReceiverTest {
     );
   }
 
-  function testFuzz_RevertIf_OwnerIsNotTheCaller(uint16 sourceChain, address sender, address caller) public {
+  function testFuzz_RevertIf_OwnerIsNotTheCaller(uint16 sourceChain, address sender, address caller)
+    public
+  {
     vm.assume(caller != receiver.owner());
     bytes32 senderBytes = bytes32(uint256(uint160(address(sender))));
 

--- a/test/WormholeReceiver.t.sol
+++ b/test/WormholeReceiver.t.sol
@@ -8,7 +8,7 @@ import {WormholeReceiver} from "src/WormholeReceiver.sol";
 import {Constants} from "test/Constants.sol";
 
 contract WormholeReceiverTestHarness is WormholeReceiver {
-  constructor(address _relayer) WormholeBase(_relayer) WormholeReceiver(msg.sender) {}
+  constructor(address _relayer, address _owner) WormholeBase(_relayer) WormholeReceiver(_owner) {}
   function receiveWormholeMessages(
     bytes memory payload,
     bytes[] memory additionalVaas,
@@ -31,13 +31,13 @@ contract WormholeReceiverTest is Test, Constants {
   WormholeReceiverTestHarness receiver;
 
   function setUp() public {
-    receiver = new WormholeReceiverTestHarness(L1_CHAIN.wormholeRelayer);
+    receiver = new WormholeReceiverTestHarness(L1_CHAIN.wormholeRelayer, msg.sender);
   }
 }
 
 contract OnlyRelayer is Test, Constants {
   function testFuzz_SucceedIfCalledByWormholeRelayer(address relayer) public {
-    WormholeReceiverTestHarness receiver = new WormholeReceiverTestHarness(relayer);
+    WormholeReceiverTestHarness receiver = new WormholeReceiverTestHarness(relayer, msg.sender);
 
     vm.prank(relayer);
     receiver.onlyRelayerModifierFunc();
@@ -45,7 +45,7 @@ contract OnlyRelayer is Test, Constants {
 
   function testFuzz_RevertIf_NotCalledByWormholeRelayer(address relayer) public {
     vm.assume(relayer != address(this));
-    WormholeReceiverTestHarness receiver = new WormholeReceiverTestHarness(relayer);
+    WormholeReceiverTestHarness receiver = new WormholeReceiverTestHarness(relayer, msg.sender);
 
     vm.expectRevert(WormholeReceiver.OnlyRelayerAllowed.selector);
     receiver.onlyRelayerModifierFunc();
@@ -55,6 +55,9 @@ contract OnlyRelayer is Test, Constants {
 contract SetRegisteredSender is WormholeReceiverTest {
   function testFuzz_SuccessfullySetRegisteredSender(uint16 sourceChain, address sender) public {
     bytes32 senderBytes = bytes32(uint256(uint160(address(sender))));
+    assertEq(receiver.owner(), msg.sender, "Owner is incorrect");
+
+    vm.prank(receiver.owner());
     receiver.setRegisteredSender(sourceChain, senderBytes);
 
     assertEq(
@@ -63,12 +66,24 @@ contract SetRegisteredSender is WormholeReceiverTest {
       "Registered sender on source chain is not correct"
     );
   }
+
+  function testFuzz_RevertIf_OwnerIsNotTheCaller(uint16 sourceChain, address sender, address caller) public {
+    vm.assume(caller != receiver.owner());
+    bytes32 senderBytes = bytes32(uint256(uint160(address(sender))));
+
+    vm.expectRevert(bytes("Ownable: caller is not the owner"));
+    vm.prank(caller);
+    receiver.setRegisteredSender(sourceChain, senderBytes);
+  }
 }
 
 contract IsRegisteredSender is WormholeReceiverTest {
   function testFuzz_SuccessfullyCallWithRegisteredSender(uint16 sourceChain, address sender) public {
     vm.assume(sender != address(0));
     bytes32 senderBytes = bytes32(uint256(uint160(address(sender))));
+    assertEq(receiver.owner(), msg.sender, "Owner is incorrect");
+
+    vm.prank(receiver.owner());
     receiver.setRegisteredSender(sourceChain, senderBytes);
     receiver.isRegisteredSenderModifierFunc(sourceChain, senderBytes);
   }

--- a/test/mock/GovernorMetadataMock.sol
+++ b/test/mock/GovernorMetadataMock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {WormholeL2GovernorMetadata} from "src/WormholeL2GovernorMetadata.sol";
 
 contract GovernorMetadataMock is WormholeL2GovernorMetadata {
-  constructor(address _core) WormholeL2GovernorMetadata(_core) {
+  constructor(address _core) WormholeL2GovernorMetadata(_core, msg.sender) {
     _proposals[1] = Proposal({voteStart: block.number, voteEnd: block.number + 3000});
   }
 


### PR DESCRIPTION
Description

- Pass in owner as an argument to avoid having to tie the deployment wallet to the contracts.

Closes #44 