### PR TITLE
Rename SOURCE_CHAIN in refund context

### DIFF
--- a/src/WormholeL1ERC20Bridge.sol
+++ b/src/WormholeL1ERC20Bridge.sol
@@ -68,7 +68,7 @@ contract WormholeL1ERC20Bridge is WormholeL1VotePool, WormholeSender, WormholeRe
       mintCalldata,
       0, // no receiver value needed since we're just passing a message
       GAS_LIMIT,
-      SOURCE_CHAIN,
+      REFUND_CHAIN,
       msg.sender
     );
   }

--- a/src/WormholeL1GovernorMetadataBridge.sol
+++ b/src/WormholeL1GovernorMetadataBridge.sol
@@ -58,7 +58,7 @@ contract WormholeL1GovernorMetadataBridge is WormholeSender {
       proposalCalldata,
       0, // no receiver value needed since we're just passing a message
       GAS_LIMIT,
-      SOURCE_CHAIN,
+      REFUND_CHAIN,
       msg.sender
     );
   }

--- a/src/WormholeL2ERC20.sol
+++ b/src/WormholeL2ERC20.sol
@@ -91,7 +91,7 @@ contract WormholeL2ERC20 is ERC20Votes, WormholeReceiver, WormholeSender {
       withdrawCalldata,
       0, // no receiver value needed since we're just passing a message
       GAS_LIMIT,
-      SOURCE_CHAIN,
+      REFUND_CHAIN,
       msg.sender
     );
   }

--- a/src/WormholeL2VoteAggregator.sol
+++ b/src/WormholeL2VoteAggregator.sol
@@ -37,7 +37,7 @@ contract WormholeL2VoteAggregator is WormholeSender, L2VoteAggregator {
       proposalCalldata,
       0, // no receiver value needed since we're just passing a message
       GAS_LIMIT,
-      SOURCE_CHAIN,
+      REFUND_CHAIN,
       msg.sender
     );
   }

--- a/src/WormholeSender.sol
+++ b/src/WormholeSender.sol
@@ -7,16 +7,16 @@ abstract contract WormholeSender is WormholeBase {
   /// @notice The chain id that is receiving the messages.
   uint16 public immutable TARGET_CHAIN;
 
-  /// @notice The chain id that is sending the messages.
-  uint16 public immutable SOURCE_CHAIN;
+  /// @notice The chain id where refunds will be sent.
+  uint16 public immutable REFUND_CHAIN;
 
   /// @notice The gas limit for cross chain transactions.
   uint256 constant GAS_LIMIT = 500_000;
 
+  /// @param _refundChain The chain id of the chain sending the messages.
   /// @param _targetChain The chain id of the chain receiving the messages.
-  /// @param _sourceChain The chain id of the chain sending the messages.
-  constructor(uint16 _sourceChain, uint16 _targetChain) {
-    SOURCE_CHAIN = _sourceChain;
+  constructor(uint16 _refundChain, uint16 _targetChain) {
+    REFUND_CHAIN = _refundChain;
     TARGET_CHAIN = _targetChain;
   }
 

--- a/test/WormholeSender.t.sol
+++ b/test/WormholeSender.t.sol
@@ -49,7 +49,7 @@ contract Constructor is WormholeSenderTest {
       _wormholeRelayer,
       "Wormhole relayer is not set correctly"
     );
-    assertEq(newSender.SOURCE_CHAIN(), _sourceChain, "Source chain is not correctly set");
+    assertEq(newSender.REFUND_CHAIN(), _sourceChain, "Source chain is not correctly set");
     assertEq(newSender.TARGET_CHAIN(), _targetChain, "Target chain is not correctly set");
   }
 }


### PR DESCRIPTION
#### Description

- Rename `SOURCE_CHAIN` to `REFUND_CHAIN` so it isn't confused with `sourceChain` in `receiveWormholeMessages`.

Closes #47 