### PR TITLE
Tally compatible events

### DIFF
--- a/src/L1VotePool.sol
+++ b/src/L1VotePool.sol
@@ -9,7 +9,7 @@ abstract contract L1VotePool {
 
   event VoteCast(
     address indexed voter,
-    uint256 indexed proposalId,
+    uint256 proposalId,
     uint256 voteAgainst,
     uint256 voteFor,
     uint256 voteAbstain

--- a/src/L2GovernorMetadata.sol
+++ b/src/L2GovernorMetadata.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/Strings.sol";
+
 /// @notice This contract is used by an L2VoteAggregator to store proposal metadata.
 /// It expects to receive proposal metadata from a valid L1 source.
 /// Derived contracts are responsible for processing and validating incoming metadata.
@@ -15,9 +17,19 @@ abstract contract L2GovernorMetadata {
   /// @notice The id of the proposal mapped to the proposal metadata.
   mapping(uint256 proposalId => Proposal) _proposals;
 
-  event ProposalAdded(
-    uint256 indexed proposalId, uint256 voteStart, uint256 voteEnd, bool isCanceled
+  event ProposalCreated(
+    uint256 proposalId,
+    address proposer,
+    address[] targets,
+    uint256[] values,
+    string[] signatures,
+    bytes[] calldatas,
+    uint256 startBlock,
+    uint256 endBlock,
+    string description
   );
+
+  event ProposalCanceled(uint256 proposalId);
 
   /// @notice Add proposal to internal storage.
   /// @param proposalId The id of the proposal.
@@ -28,7 +40,21 @@ abstract contract L2GovernorMetadata {
     virtual
   {
     _proposals[proposalId] = Proposal(voteStart, voteEnd, isCanceled);
-    emit ProposalAdded(proposalId, voteStart, voteEnd, isCanceled);
+    if (isCanceled) {
+      emit ProposalCanceled(proposalId);
+    } else {
+      emit ProposalCreated(
+        proposalId,
+        address(0),
+        new address[](0),
+        new uint256[](0),
+        new string[](0),
+        new bytes[](0),
+        voteStart,
+        voteEnd,
+        string.concat("Mainnet proposal ", Strings.toString(proposalId))
+      );
+    }
   }
 
   /// @notice Returns the proposal metadata for a given proposal id.

--- a/test/WormholeL1GovernorMetadataBridge.t.sol
+++ b/test/WormholeL1GovernorMetadataBridge.t.sol
@@ -10,6 +10,7 @@ import {FakeERC20} from "src/FakeERC20.sol";
 import {L2GovernorMetadata} from "src/L2GovernorMetadata.sol";
 import {WormholeL2GovernorMetadata} from "src/WormholeL2GovernorMetadata.sol";
 import {TestConstants} from "test/Constants.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {GovernorMock} from "test/mock/GovernorMock.sol";
 
 contract L1GovernorMetadataBridgeTest is TestConstants, WormholeRelayerBasicTest {
@@ -18,8 +19,16 @@ contract L1GovernorMetadataBridgeTest is TestConstants, WormholeRelayerBasicTest
   WormholeL1GovernorMetadataBridge l1GovernorMetadataBridge;
   WormholeL2GovernorMetadata l2GovernorMetadata;
 
-  event ProposalAdded(
-    uint256 indexed proposalId, uint256 voteStart, uint256 voteEnd, bool isCanceled
+  event ProposalCreated(
+    uint256 proposalId,
+    address proposer,
+    address[] targets,
+    uint256[] values,
+    string[] signatures,
+    bytes[] calldatas,
+    uint256 startBlock,
+    uint256 endBlock,
+    string description
   );
   event ProposalMetadataBridged(
     uint16 indexed targetChain,
@@ -116,7 +125,17 @@ contract BridgeProposalMetadata is L1GovernorMetadataBridgeTest {
     uint256 l1VoteEnd = governorMock.proposalDeadline(proposalId);
 
     vm.expectEmit();
-    emit ProposalAdded(proposalId, l1VoteStart, l1VoteEnd, false);
+    emit ProposalCreated(
+      proposalId,
+      address(0),
+      new address[](0),
+      new uint256[](0),
+      new string[](0),
+      new bytes[](0),
+      l1VoteStart,
+      l1VoteEnd,
+      string.concat("Mainnet proposal ", Strings.toString(proposalId))
+    );
     performDelivery();
 
     vm.selectFork(targetFork);

--- a/test/WormholeL1VotePool.t.sol
+++ b/test/WormholeL1VotePool.t.sol
@@ -157,7 +157,7 @@ contract L1VotePoolTest is TestConstants, WormholeRelayerBasicTest {
 
   event VoteCast(
     address indexed voter,
-    uint256 indexed proposalId,
+    uint256 proposalId,
     uint256 voteAgainst,
     uint256 voteFor,
     uint256 voteAbstain

--- a/test/WormholeL2VoteAggregator.t.sol
+++ b/test/WormholeL2VoteAggregator.t.sol
@@ -61,11 +61,7 @@ contract L2VoteAggregatorTest is TestConstants, WormholeRelayerBasicTest {
   );
 
   event VoteCast(
-    address indexed voter,
-    uint256 indexed proposalId,
-    uint256 against,
-    uint256 inFavor,
-    uint256 abstain
+    address indexed voter, uint256 proposalId, uint256 against, uint256 inFavor, uint256 abstain
   );
   event VoteBridged(
     uint256 indexed proposalId, uint256 voteAgainst, uint256 voteFor, uint256 voteAbstain


### PR DESCRIPTION
Events comport w/ following tally events:

### Event Signature
```solidity
event ProposalCreated(
    uint256 proposalId,
    address proposer,
    address[] targets,
    uint256[] values,
    string[] signatures,
    bytes[] calldatas,
    uint256 startBlock,
    uint256 endBlock,
    string description
);
```

----

```solidity
event ProposalCanceled(uint256 proposalId);
```

----

```solidity
event VoteCast(
    address indexed voter, 
    uint256 proposalId, 
    uint8 support, 
    uint256 weight, 
    string reason
);
```