### PR TITLE
Dynamic block conversion

### DIFF
--- a/src/L2GovernorMetadata.sol
+++ b/src/L2GovernorMetadata.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/utils/Strings.sol";
 import {IL1Block} from "src/interfaces/IL1Block.sol";
 
-/// @notice This contract is used by an L2VoteAggregator to store proposal metadata.
+/// @notice This contract is used by an `L2VoteAggregator` to store proposal metadata.
 /// It expects to receive proposal metadata from a valid L1 source.
 /// Derived contracts are responsible for processing and validating incoming metadata.
 abstract contract L2GovernorMetadata {
@@ -20,22 +20,22 @@ abstract contract L2GovernorMetadata {
 
   /// @notice The assumed block time of the base network
   uint256 private L1_BLOCK_TIME = 12;
-  /// @notice The assumed block time of the aux network
+  /// @notice The assumed block time of the target network
   /// @dev These are hardcoded now for Ethereum mainnet & Optimism, as these are currently
   /// the target networks for the MVP launch. In the future, this should be generalized to work
   /// for different network combinations. Even better, once we have better support for cross chain
   /// voting in clients and frontend tools, this hack should removed completely.
   uint256 private L2_BLOCK_TIME = 2;
 
-  /// @notice The contract that handles fetch the L1 block on the L2.
+  /// @notice The contract that handles fetching the L1 block on the L2.
   /// @dev If the block conversion hack is removed from this contract, then this storage var is
-  /// probably not needed in this contract and can probably be moved back to the L2VoteAggregator
+  /// probably not needed in this contract and can probably be moved back to the `L2VoteAggregator`
   IL1Block public immutable L1_BLOCK;
 
   /// @notice The number of blocks on L1 before L2 voting closes. We close voting 1200 blocks
   // before the end of the proposal to cast the vote.
   /// @dev If the block conversion hack is removed from this contract, then this storage var is
-  /// probably not needed in this contract and can probably be moved back to the L2VoteAggregator
+  /// probably not needed in this contract and can probably be moved back to the `L2VoteAggregator`
   uint32 public constant CAST_VOTE_WINDOW = 1200;
 
   event ProposalCreated(
@@ -91,7 +91,7 @@ abstract contract L2GovernorMetadata {
   }
 
   /// @notice Calculate the approximate block that the L2 will be producing at the time the
-  /// L1 produces some given future block number.abi
+  /// L1 produces some given future block number.
   /// @param _l1BlockNumber The number of a future L1 block
   /// @return The approximate block number the L2 will be producing when L1 produces the given
   /// block

--- a/src/L2VoteAggregator.sol
+++ b/src/L2VoteAggregator.sol
@@ -7,14 +7,9 @@ import {EIP712} from "openzeppelin/utils/cryptography/EIP712.sol";
 import {ECDSA} from "openzeppelin/utils/cryptography/ECDSA.sol";
 
 import {L2GovernorMetadata} from "src/WormholeL2GovernorMetadata.sol";
-import {IL1Block} from "src/interfaces/IL1Block.sol";
 
 /// @notice A contract to collect votes on L2 to be bridged to L1.
 abstract contract L2VoteAggregator is EIP712, L2GovernorMetadata {
-  /// @notice The number of blocks before L2 voting closes. We close voting 1200 blocks before the
-  /// end of the proposal to cast the vote.
-  uint32 public constant CAST_VOTE_WINDOW = 1200;
-
   bytes32 public constant BALLOT_TYPEHASH = keccak256("Ballot(uint256 proposalId,uint8 support)");
 
   /// @notice The token used to vote on proposals provided by the `GovernorMetadata`.
@@ -22,9 +17,6 @@ abstract contract L2VoteAggregator is EIP712, L2GovernorMetadata {
 
   /// @notice The address of the bridge that receives L2 votes.
   address public L1_BRIDGE_ADDRESS;
-
-  /// @notice The contract that handles fetch the L1 block on the L2.
-  IL1Block public immutable L1_BLOCK;
 
   /// @notice Used to indicate whether the contract has been initialized with the L1 bridge address.
   bool public INITIALIZED = false;
@@ -92,10 +84,8 @@ abstract contract L2VoteAggregator is EIP712, L2GovernorMetadata {
   );
 
   /// @param _votingToken The token used to vote on proposals.
-  /// @param _l1BlockAddress The address of the L1Block contract.
-  constructor(address _votingToken, address _l1BlockAddress) EIP712("L2VoteAggregator", "1") {
+  constructor(address _votingToken) EIP712("L2VoteAggregator", "1") {
     VOTING_TOKEN = ERC20Votes(_votingToken);
-    L1_BLOCK = IL1Block(_l1BlockAddress);
   }
 
   function initialize(address l1BridgeAddress) public {

--- a/src/WormholeL2GovernorMetadata.sol
+++ b/src/WormholeL2GovernorMetadata.sol
@@ -9,10 +9,10 @@ import {L2GovernorMetadata} from "src/L2GovernorMetadata.sol";
 contract WormholeL2GovernorMetadata is L2GovernorMetadata, WormholeReceiver {
   /// @param _relayer The address of the WormholeL2GovernorMetadata contract.
   /// @param _owner The address that will become the contract owner.
-  constructor(address _relayer, address _owner)
+  constructor(address _relayer, address _owner, address _l1BlockAddress)
     WormholeBase(_relayer)
     WormholeReceiver(_owner)
-    L2GovernorMetadata()
+    L2GovernorMetadata(_l1BlockAddress)
   {}
 
   /// @notice Receives a message from L1 and saves the proposal metadata.

--- a/src/WormholeL2VoteAggregator.sol
+++ b/src/WormholeL2VoteAggregator.sol
@@ -22,9 +22,9 @@ contract WormholeL2VoteAggregator is WormholeSender, L2VoteAggregator, WormholeL
     uint16 _targetChain,
     address _owner
   )
-    L2VoteAggregator(_votingToken, _l1BlockAddress)
+    L2VoteAggregator(_votingToken)
     WormholeSender(_sourceChain, _targetChain)
-    WormholeL2GovernorMetadata(_relayer, _owner) // to see if it builds
+    WormholeL2GovernorMetadata(_relayer, _owner, _l1BlockAddress)
   {}
 
   /// @notice Wormhole-specific implementation of `_bridgeVote`.

--- a/src/optimized/WormholeL2GovernorMetadataOptimized.sol
+++ b/src/optimized/WormholeL2GovernorMetadataOptimized.sol
@@ -11,7 +11,9 @@ contract WormholeL2GovernorMetadataOptimized is WormholeL2GovernorMetadata {
   /// @notice The ID of the proposal mapped to an internal proposal ID.
   mapping(uint256 governorProposalId => uint16) public optimizedProposalIds;
 
-  constructor(address _relayer, address _owner) WormholeL2GovernorMetadata(_relayer, _owner) {}
+  constructor(address _relayer, address _owner, address _l1BlockAddress)
+    WormholeL2GovernorMetadata(_relayer, _owner, _l1BlockAddress)
+  {}
 
   /// @inheritdoc L2GovernorMetadata
   function _addProposal(uint256 proposalId, uint256 voteStart, uint256 voteEnd, bool isCanceled)

--- a/test/Constants.sol
+++ b/test/Constants.sol
@@ -90,6 +90,9 @@ contract BaseConstants is CommonBase {
 contract ScriptConstants is BaseConstants {}
 
 contract TestConstants is BaseConstants, Test {
-  bytes32 MOCK_WORMHOLE_SERIALIZED_ADDRESS =
-    bytes32(uint256(uint160(0xEAC5F0d4A9a45E1f9FdD0e7e2882e9f60E301156)));
+  address constant ARBITRARY_ADDRESS = 0xEAC5F0d4A9a45E1f9FdD0e7e2882e9f60E301156;
+  bytes32 constant MOCK_WORMHOLE_SERIALIZED_ADDRESS = bytes32(uint256(uint160(ARBITRARY_ADDRESS)));
+
+  // An arbitrary, large, mainnet-block-like number for use with the mock L1 Block
+  uint64 constant MOCK_L1_BLOCK = 18_442_511;
 }

--- a/test/L2GovernorMetadata.t.sol
+++ b/test/L2GovernorMetadata.t.sol
@@ -12,8 +12,6 @@ contract L2GovernorMetadataTest is TestConstants {
   L2GovernorMetadataHarness l2GovernorMetadata;
   L1BlockMock mockL1Block;
 
-  uint64 constant MOCK_L1_BLOCK = 18_442_511;
-
   event ProposalCreated(
     uint256 proposalId,
     address proposer,

--- a/test/WormholeL1GovernorMetadataBridge.t.sol
+++ b/test/WormholeL1GovernorMetadataBridge.t.sol
@@ -12,6 +12,7 @@ import {WormholeL2GovernorMetadata} from "src/WormholeL2GovernorMetadata.sol";
 import {TestConstants} from "test/Constants.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {GovernorMock} from "test/mock/GovernorMock.sol";
+import {L1BlockMock} from "test/mock/L1BlockMock.sol";
 
 contract L1GovernorMetadataBridgeTest is TestConstants, WormholeRelayerBasicTest {
   FakeERC20 l1Erc20;
@@ -52,7 +53,9 @@ contract L1GovernorMetadataBridgeTest is TestConstants, WormholeRelayerBasicTest
   }
 
   function setUpTarget() public override {
-    l2GovernorMetadata = new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender);
+    L1BlockMock _mockL1Block = new L1BlockMock();
+    l2GovernorMetadata =
+      new WormholeL2GovernorMetadata(L2_CHAIN.wormholeRelayer, msg.sender, address(_mockL1Block));
     vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, bytes32(uint256(uint160(address(l1GovernorMetadataBridge))))

--- a/test/WormholeL2GovernorMetadata.t.sol
+++ b/test/WormholeL2GovernorMetadata.t.sol
@@ -65,9 +65,8 @@ contract L2GovernorMetadataTest is TestConstants {
 
 contract Constructor is L2GovernorMetadataTest {
   function testFuzz_CorrectlySetsAllArgs(address wormholeCore) public {
-    new WormholeL2GovernorMetadata(wormholeCore, msg.sender, address(0x1b)); // nothing to assert as
-      // there are no
-      // constructor args set
+    new WormholeL2GovernorMetadata(wormholeCore, msg.sender, address(ARBITRARY_ADDRESS));
+    // nothing to assert as there are no constructor args set
   }
 }
 

--- a/test/harness/L2GovernorMetadataHarness.sol
+++ b/test/harness/L2GovernorMetadataHarness.sol
@@ -5,6 +5,8 @@ import {L2GovernorMetadata} from "src/L2GovernorMetadata.sol";
 import {TestConstants} from "test/Constants.sol";
 
 contract L2GovernorMetadataHarness is L2GovernorMetadata {
+  constructor(address _l1BlockAddress) L2GovernorMetadata(_l1BlockAddress) {}
+
   function exposed_proposals(uint256 proposalId) public view returns (Proposal memory) {
     return _proposals[proposalId];
   }

--- a/test/harness/L2VoteAggregatorHarness.sol
+++ b/test/harness/L2VoteAggregatorHarness.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.20;
 
 import {L2VoteAggregator} from "src/L2VoteAggregator.sol";
 import {WormholeL2VoteAggregator} from "src/WormholeL2VoteAggregator.sol";
-import {GovernorMetadataMockBase} from "test/mock/GovernorMetadataMock.sol";
+import {GovernorMetadataMockBase, L2GovernorMetadata} from "test/mock/GovernorMetadataMock.sol";
 
 contract L2VoteAggregatorHarness is L2VoteAggregator, GovernorMetadataMockBase {
   constructor(address _votingToken, address _l1BlockAddress)
-    L2VoteAggregator(_votingToken, _l1BlockAddress)
+    L2VoteAggregator(_votingToken)
+    L2GovernorMetadata(_l1BlockAddress)
   {}
 
   function _bridgeVote(bytes memory) internal override {}

--- a/test/harness/optimized/WormholeL2GovernorMetadataOptimizedHarness.sol
+++ b/test/harness/optimized/WormholeL2GovernorMetadataOptimizedHarness.sol
@@ -5,7 +5,9 @@ import {WormholeL2GovernorMetadataOptimized} from
   "src/optimized/WormholeL2GovernorMetadataOptimized.sol";
 
 contract WormholeL2GovernorMetadataOptimizedHarness is WormholeL2GovernorMetadataOptimized {
-  constructor(address _core, address _owner) WormholeL2GovernorMetadataOptimized(_core, _owner) {}
+  constructor(address _core, address _owner, address _l1BlockAddress)
+    WormholeL2GovernorMetadataOptimized(_core, _owner, _l1BlockAddress)
+  {}
 
   function exposed_addProposal(
     uint256 proposalId,

--- a/test/mock/GovernorMetadataMock.sol
+++ b/test/mock/GovernorMetadataMock.sol
@@ -45,7 +45,7 @@ abstract contract GovernorMetadataMockBase is L2GovernorMetadata {
 }
 
 contract GovernorMetadataMock is GovernorMetadataMockBase, WormholeL2GovernorMetadata {
-  constructor(address _core) WormholeL2GovernorMetadata(_core, msg.sender) {
+  constructor(address _core) WormholeL2GovernorMetadata(_core, msg.sender, address(0x1b)) {
     _proposals[1] =
       Proposal({voteStart: block.number, voteEnd: block.number + 3000, isCanceled: false});
   }
@@ -55,7 +55,7 @@ contract GovernorMetadataOptimizedMock is
   GovernorMetadataMockBase,
   WormholeL2GovernorMetadataOptimized
 {
-  constructor(address _core) WormholeL2GovernorMetadataOptimized(_core, msg.sender) {}
+  constructor(address _core) WormholeL2GovernorMetadataOptimized(_core, msg.sender, address(0x1b)) {}
 
   function _addProposal(uint256 proposalId, uint256 voteStart, uint256 voteEnd, bool isCanceled)
     internal

--- a/test/mock/L1BlockMock.sol
+++ b/test/mock/L1BlockMock.sol
@@ -2,20 +2,18 @@
 pragma solidity ^0.8.0;
 
 import {IL1Block} from "src/interfaces/IL1Block.sol";
-import {StdUtils} from "forge-std/Test.sol";
+import {TestConstants} from "test/Constants.sol";
 
 /// @dev For use in proposal related tests that need access to the L1Block only for the purpose of
 /// calculating an L2 block to emit in the proposal created events, for the sake of compatibility
 /// with existing frontend clients.
-contract L1BlockMock is IL1Block, StdUtils {
-  // An arbitrary, large, mainnet-block-like number for use with the mock L1 Block
-  uint64 private NUMBER = 18_442_511;
+contract L1BlockMock is IL1Block, TestConstants {
   uint64 private TIMESTAMP = 0;
   uint256 private BASEFEE = 0;
-  bytes32 private HASH = blockhash(NUMBER);
+  bytes32 private HASH = blockhash(MOCK_L1_BLOCK);
 
-  function number() external view returns (uint64) {
-    return NUMBER;
+  function number() external pure returns (uint64) {
+    return MOCK_L1_BLOCK;
   }
 
   function timestamp() external view returns (uint64) {
@@ -31,19 +29,19 @@ contract L1BlockMock is IL1Block, StdUtils {
   }
 
   /// @dev For use in tests to ensure a fuzzed L1 block vote end conforms to the internal invariant
-  /// requirements inside the L2GovernorMetadata
+  /// requirements inside the L2GovernorMetadata.
   function __boundL1VoteEnd(uint256 _l1VoteEnd) public view returns (uint256) {
-    return bound(_l1VoteEnd, NUMBER + 3000, NUMBER + 2_628_000);
+    return bound(_l1VoteEnd, MOCK_L1_BLOCK + 3000, MOCK_L1_BLOCK + 2_628_000);
   }
 
-  /// @dev Matches the implementation inside L2GovernorMetadata for the sake of test expectations
-  function __expectedL2BlockForFutureBlock(uint256 _l1BlockNumber) external view returns (uint256) {
+  /// @dev Matches the implementation inside L2GovernorMetadata for the sake of test expectations.
+  function __expectedL2BlockForFutureBlock(uint256 _l1BlockNumber) external pure returns (uint256) {
     require(
-      _l1BlockNumber > NUMBER + 1200,
+      _l1BlockNumber > MOCK_L1_BLOCK + 1200,
       "L1BlockMock: Bad test parameters, _l1BlockNumber must be greater than mock current block number"
     );
 
-    uint256 _l1BlocksUntilEnd = _l1BlockNumber - NUMBER - 1200;
+    uint256 _l1BlocksUntilEnd = _l1BlockNumber - MOCK_L1_BLOCK - 1200;
     return (_l1BlocksUntilEnd * 12) / 2;
   }
 }

--- a/test/mock/L1BlockMock.sol
+++ b/test/mock/L1BlockMock.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IL1Block} from "src/interfaces/IL1Block.sol";
+import {StdUtils} from "forge-std/Test.sol";
+
+/// @dev For use in proposal related tests that need access to the L1Block only for the purpose of
+/// calculating an L2 block to emit in the proposal created events, for the sake of compatibility
+/// with existing frontend clients.
+contract L1BlockMock is IL1Block, StdUtils {
+  // An arbitrary, large, mainnet-block-like number for use with the mock L1 Block
+  uint64 private NUMBER = 18_442_511;
+  uint64 private TIMESTAMP = 0;
+  uint256 private BASEFEE = 0;
+  bytes32 private HASH = blockhash(NUMBER);
+
+  function number() external view returns (uint64) {
+    return NUMBER;
+  }
+
+  function timestamp() external view returns (uint64) {
+    return TIMESTAMP;
+  }
+
+  function basefee() external view returns (uint256) {
+    return BASEFEE;
+  }
+
+  function hash() external view returns (bytes32) {
+    return HASH;
+  }
+
+  /// @dev For use in tests to ensure a fuzzed L1 block vote end conforms to the internal invariant
+  /// requirements inside the L2GovernorMetadata
+  function __boundL1VoteEnd(uint256 _l1VoteEnd) public view returns (uint256) {
+    return bound(_l1VoteEnd, NUMBER + 3000, NUMBER + 2_628_000);
+  }
+
+  /// @dev Matches the implementation inside L2GovernorMetadata for the sake of test expectations
+  function __expectedL2BlockForFutureBlock(uint256 _l1BlockNumber) external view returns (uint256) {
+    require(
+      _l1BlockNumber > NUMBER + 1200,
+      "L1BlockMock: Bad test parameters, _l1BlockNumber must be greater than mock current block number"
+    );
+
+    uint256 _l1BlocksUntilEnd = _l1BlockNumber - NUMBER - 1200;
+    return (_l1BlocksUntilEnd * 12) / 2;
+  }
+}

--- a/test/optimized/WormholeL2GovernorMetadataOptimized.t.sol
+++ b/test/optimized/WormholeL2GovernorMetadataOptimized.t.sol
@@ -7,13 +7,16 @@ import {L2GovernorMetadata} from "src/L2GovernorMetadata.sol";
 import {WormholeL2GovernorMetadataOptimizedHarness} from
   "test/harness/optimized/WormholeL2GovernorMetadataOptimizedHarness.sol";
 import {TestConstants} from "test/Constants.sol";
+import {L1BlockMock} from "test/mock/L1BlockMock.sol";
 
 contract WormholeL2GovernorMetadataOptimizedTest is TestConstants {
   WormholeL2GovernorMetadataOptimizedHarness l2GovernorMetadata;
+  L1BlockMock mockL1Block;
 
   function setUp() public {
+    mockL1Block = new L1BlockMock();
     l2GovernorMetadata =
-      new WormholeL2GovernorMetadataOptimizedHarness(L2_CHAIN.wormholeRelayer, msg.sender);
+    new WormholeL2GovernorMetadataOptimizedHarness(L2_CHAIN.wormholeRelayer, msg.sender, address(mockL1Block));
     vm.prank(l2GovernorMetadata.owner());
     l2GovernorMetadata.setRegisteredSender(
       L1_CHAIN.wormholeChainId, MOCK_WORMHOLE_SERIALIZED_ADDRESS
@@ -28,6 +31,7 @@ contract _AddProposal is WormholeL2GovernorMetadataOptimizedTest {
     uint256 l1VoteEnd,
     bool isCanceled
   ) public {
+    l1VoteEnd = mockL1Block.__boundL1VoteEnd(l1VoteEnd);
     l2GovernorMetadata.exposed_addProposal(proposalId, l1VoteStart, l1VoteEnd, isCanceled);
     L2GovernorMetadata.Proposal memory l2Proposal = l2GovernorMetadata.getProposal(proposalId);
     uint256 internalProposalId = l2GovernorMetadata.optimizedProposalIds(proposalId);
@@ -52,6 +56,10 @@ contract _AddProposal is WormholeL2GovernorMetadataOptimizedTest {
   ) public {
     uint256 secondProposalId = uint256(keccak256(abi.encodePacked(firstProposalId)));
     uint256 thirdProposalId = uint256(keccak256(abi.encodePacked(secondProposalId)));
+
+    firstL1VoteEnd = mockL1Block.__boundL1VoteEnd(firstL1VoteEnd);
+    secondL1VoteEnd = mockL1Block.__boundL1VoteEnd(secondL1VoteEnd);
+    thirdL1VoteEnd = mockL1Block.__boundL1VoteEnd(thirdL1VoteEnd);
 
     l2GovernorMetadata.exposed_addProposal(
       firstProposalId, firstL1VoteStart, firstL1VoteEnd, firstIsCanceled
@@ -86,6 +94,8 @@ contract _AddProposal is WormholeL2GovernorMetadataOptimizedTest {
     uint256 updatedVoteEnd,
     bool updatedIsCanceled
   ) public {
+    initialVoteEnd = mockL1Block.__boundL1VoteEnd(initialVoteEnd);
+    updatedVoteEnd = mockL1Block.__boundL1VoteEnd(updatedVoteEnd);
     l2GovernorMetadata.exposed_addProposal(
       proposalId, initialVoteStart, initialVoteEnd, initialIsCanceled
     );


### PR DESCRIPTION
Calculate the approximate L2 block that will be produced when the L1 proposal closes and emit that in the proposal created event when governor metadata is bridged. We do this as somewhat of a hack for compatibility with existing tooling.

closes #86 